### PR TITLE
Updates for core20 and gnome-3-38

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,87 +1,37 @@
 name: gnome-taquin
-version: 3.36.7
-summary: Slide tiles to their correct places
-description: |
-  Taquin is a computer version of the 15-puzzle and other sliding puzzles.
-
-  The object of Taquin is to move tiles so that they reach their places,
-  either indicated with numbers, or with parts of a great image.
-
+adopt-info: gnome-taquin
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core18
-
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/data-dir/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/data-dir/icons
-    default-provider: gtk-common-themes
+base: core20
 
 slots:
   # for GtkApplication registration
   gnome-taquin:
     interface: dbus
     bus: session
-    name: org.gnome.taquin
+    name: org.gnome.Taquin
 
 apps:
   gnome-taquin:
-    command: desktop-launch gnome-taquin
+    extensions: [ gnome-3-38 ]
+    command: usr/bin/gnome-taquin
     plugs:
-      - desktop
-      - desktop-legacy
-      - gsettings
-      - unity7
-      - wayland
-    desktop: usr/share/applications/org.gnome.taquin.desktop
-    environment:
-      PATH: $SNAP/usr/games:$PATH
+      - audio-playback
+    desktop: usr/share/applications/org.gnome.Taquin.desktop
 
 parts:
-  desktop-gnome-platform:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
-    plugin: make
-    make-parameters: ["FLAVOR=gtk3"]
-    build-packages:
-      - build-essential
-      - libgtk-3-dev
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
-
   gnome-taquin:
-    after: [desktop-gnome-platform]
     source: https://gitlab.gnome.org/GNOME/gnome-taquin.git
     source-type: git
-    source-branch: gnome-3-36
+    source-tag: '3.38.1'
+    parse-info: [usr/share/metainfo/org.gnome.Taquin.appdata.xml]
     override-build: |
-      sed -i.bak -e 's|=gnome-taquin$|=${SNAP}/meta/gui/gnome-taquin.png|g' data/org.gnome.taquin.desktop.in
+      sed -i.bak -e 's|=gnome-taquin$|=${SNAP}/meta/gui/org.gnome.Taquin.svg|g' $SNAPCRAFT_PART_SRC/data/org.gnome.Taquin.desktop.in
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
-      cp ../src/data/icons/hicolor/256x256/gnome-taquin.png $SNAPCRAFT_PART_INSTALL/meta/gui/
-      cp data/org.gnome.taquin.desktop $SNAPCRAFT_PART_INSTALL/meta/gui/
-    plugin: autotools
-    configflags: [--prefix=/snap/gnome-taquin/current/usr, --bindir=/snap/gnome-taquin/current/usr/games]
+      cp $SNAPCRAFT_PART_SRC/data/icons/hicolor/scalable/org.gnome.Taquin.svg $SNAPCRAFT_PART_INSTALL/meta/gui/
+      cp data/org.gnome.Taquin.desktop $SNAPCRAFT_PART_INSTALL/meta/gui/
+    plugin: meson
+    meson-parameters: [--prefix=/snap/gnome-taquin/current/usr]
     organize:
       snap/gnome-taquin/current/usr: usr
-    build-packages:
-     - appstream-util
-     - gnome-pkg-tools
-     - pkg-config
-     - intltool
-     - libglib2.0-dev
-     - libgtk-3-dev
-     - librsvg2-dev
-     - libcanberra-gtk3-dev
-     - valac
-     - yelp-tools
-


### PR DESCRIPTION
## Description

Updated to core20 and gnome-3-38 extension.
This is a re-opening of #1 1

## Type of change

Please check only the options that are relevant.

- [x] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I built the snap locally, installed it locally, launched it from the desktop icon in Activites and it looks good.

snapcraft (latest/edge): 7.0.post6+gitc94bee07
OS: 22.04

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

